### PR TITLE
Adding functionality for a subtraction fade

### DIFF
--- a/Editor/Volume/CathodeRayTubeVolumeEditor.cs
+++ b/Editor/Volume/CathodeRayTubeVolumeEditor.cs
@@ -26,6 +26,7 @@ namespace HauntedPSX.RenderPipelines.PSX.Editor
         SerializedDataParameter m_BarrelDistortionX;
         SerializedDataParameter m_BarrelDistortionY;
         SerializedDataParameter m_Vignette;
+        SerializedDataParameter m_SubtractionFade;
 
         public override void OnEnable()
         {
@@ -46,6 +47,7 @@ namespace HauntedPSX.RenderPipelines.PSX.Editor
             m_BarrelDistortionX = Unpack(o.Find(x => x.barrelDistortionX));
             m_BarrelDistortionY = Unpack(o.Find(x => x.barrelDistortionY));
             m_Vignette = Unpack(o.Find(x => x.vignette));
+            m_SubtractionFade = Unpack(o.Find(x => x.subtractionFade));
         }
 
         public override void OnInspectorGUI()
@@ -66,6 +68,7 @@ namespace HauntedPSX.RenderPipelines.PSX.Editor
             PropertyField(m_BarrelDistortionX, EditorGUIUtility.TrTextContent("Barrel Distortion X", "Controls the intensity of the simulated CRT barrel distortion (fish bowl effect) horizontally."));
             PropertyField(m_BarrelDistortionY, EditorGUIUtility.TrTextContent("Barrel Distortion Y", "Controls the intensity of the simulated CRT barrel distortion (fish bowl effect) vertically."));    
             PropertyField(m_Vignette, EditorGUIUtility.TrTextContent("Vignette", "Controls the amount of image darkening that occurs at the side of the CRT screen."));
+            PropertyField(m_SubtractionFade, EditorGUIUtility.TrTextContent("Subtraction Fade", "Controls current amount of fade being applied"));
         }
     }
 }

--- a/Runtime/PostProcessing/Shaders/CRT.shader
+++ b/Runtime/PostProcessing/Shaders/CRT.shader
@@ -39,6 +39,7 @@ Shader "Hidden/HauntedPS1/CRT"
     TEXTURE2D(_WhiteNoiseTexture);
     TEXTURE2D(_BlueNoiseTexture);
     TEXTURE2D(_CRTGrateMaskTexture);
+	float _CRTFadePercent;
 
     // Emulated input resolution.
 #if 1
@@ -430,6 +431,9 @@ Shader "Hidden/HauntedPS1/CRT"
         #endif
 
         crt.rgb *= vignette;
+
+		// Subtraction Fade
+		crt.rgb = crt.rgb - _CRTFadePercent;
 
         return float4(crt.rgb, crt.a);
     }

--- a/Runtime/RenderPipeline/PSXRenderPipeline.cs
+++ b/Runtime/RenderPipeline/PSXRenderPipeline.cs
@@ -1170,6 +1170,8 @@ namespace HauntedPSX.RenderPipelines.PSX.Runtime
                 cmd.SetGlobalVector(PSXShaderIDs._CRTBarrelDistortion, new Vector2(volumeSettings.barrelDistortionX.value * 0.125f, volumeSettings.barrelDistortionY.value * 0.125f));
             
                 cmd.SetGlobalFloat(PSXShaderIDs._CRTVignetteSquared, volumeSettings.vignette.value * volumeSettings.vignette.value);
+
+                cmd.SetGlobalFloat(PSXShaderIDs._CRTFadePercent, volumeSettings.subtractionFade.value * volumeSettings.subtractionFade.value);
             }
         }
 

--- a/Runtime/RenderPipeline/PSXStringContants.cs
+++ b/Runtime/RenderPipeline/PSXStringContants.cs
@@ -127,6 +127,7 @@ namespace HauntedPSX.RenderPipelines.PSX.Runtime
         public static readonly int _CRTGrateMaskIntensityMinMax = Shader.PropertyToID("_CRTGrateMaskIntensityMinMax");
         public static readonly int _CRTBarrelDistortion = Shader.PropertyToID("_CRTBarrelDistortion");
         public static readonly int _CRTVignetteSquared = Shader.PropertyToID("_CRTVignetteSquared");
+        public static readonly int _CRTFadePercent = Shader.PropertyToID("_CRTFadePercent");
         public static readonly int _CRTIsTelevisionOverlayEnabled = Shader.PropertyToID("_CRTIsTelevisionOverlayEnabled");
         public static readonly int _PrecisionGeometry = Shader.PropertyToID("_PrecisionGeometry");
         public static readonly int _PrecisionColor = Shader.PropertyToID("_PrecisionColor");

--- a/Runtime/Volume/CathodeRayTubeVolume.cs
+++ b/Runtime/Volume/CathodeRayTubeVolume.cs
@@ -41,6 +41,7 @@ namespace HauntedPSX.RenderPipelines.PSX.Runtime
         public ClampedFloatParameter barrelDistortionX = new ClampedFloatParameter(8.0f / 64.0f, 0.0f, 1.0f);
         public ClampedFloatParameter barrelDistortionY = new ClampedFloatParameter(8.0f / 24.0f, 0.0f, 1.0f);
         public ClampedFloatParameter vignette = new ClampedFloatParameter(0.5f, 0.0f, 1.0f);
+        public ClampedFloatParameter subtractionFade = new ClampedFloatParameter(0.0f, 0.0f, 1.0f);
 
         static CathodeRayTubeVolume s_Default = null;
         public static CathodeRayTubeVolume @default


### PR DESCRIPTION
Added basic functionality for a subtraction fade within the CRT Volume. It currently applies the calculation at the end of the EvaluateCRT function in the CRT Shader. Let me know if there are any issues with this approach.