### PR TITLE
Fix for #11 Grass is unaffected by realtime lights

### DIFF
--- a/Runtime/Material/PSXTerrain/PSXWavingGrass.shader
+++ b/Runtime/Material/PSXTerrain/PSXWavingGrass.shader
@@ -38,6 +38,7 @@ Shader "Hidden/TerrainEngine/Details/PSX/WavingDoublePass"
             // exposed such as in the PSXLit material.
             // For now, simply enable all features we believe are relevant (at a performance cost).
             // #pragma shader_feature _ _VERTEX_COLOR_MODE_COLOR _VERTEX_COLOR_MODE_LIGHTING
+            #pragma shader_feature _BRDF_MODE_LAMBERT _BRDF_MODE_WRAPPED_LIGHTING
             #define _LIGHTING_BAKED_ON
             #define _LIGHTING_DYNAMIC_ON
             // #define _SHADING_EVALUATION_MODE_PER_VERTEX

--- a/Runtime/Material/PSXTerrain/PSXWavingGrassBillboard.shader
+++ b/Runtime/Material/PSXTerrain/PSXWavingGrassBillboard.shader
@@ -38,6 +38,7 @@ Shader "Hidden/TerrainEngine/Details/PSX/BillboardWavingDoublePass"
             // exposed such as in the PSXLit material.
             // For now, simply enable all features we believe are relevant (at a performance cost).
             // #pragma shader_feature _ _VERTEX_COLOR_MODE_COLOR _VERTEX_COLOR_MODE_LIGHTING
+            #pragma shader_feature _BRDF_MODE_LAMBERT _BRDF_MODE_WRAPPED_LIGHTING
             #define _LIGHTING_BAKED_ON
             #define _LIGHTING_DYNAMIC_ON
             // #define _SHADING_EVALUATION_MODE_PER_VERTEX


### PR DESCRIPTION
Here's a before/after the fix in a simple scene with:
- Basic terrain
- Ambient light color set to black
- Fog disabled
- A single point light

Tested both grass shaders via enabling/disabling billboarding on grass instances.

Before:
![Before](https://user-images.githubusercontent.com/3935328/137825280-a99ab701-27a7-4a1e-9a99-f761bdf3dd06.png)

After:
![After](https://user-images.githubusercontent.com/3935328/137825291-02f9b124-cadf-4616-9f80-db538d853527.png)


