### PR TITLE
Fix for #18 Canvas order is not considered for non-Overlay legacy Canvas UI

### DIFF
--- a/Runtime/RenderPipeline/PSXRenderPipeline.cs
+++ b/Runtime/RenderPipeline/PSXRenderPipeline.cs
@@ -1616,7 +1616,10 @@ namespace HauntedPSX.RenderPipelines.PSX.Runtime
         static void DrawLegacyCanvasUI(ScriptableRenderContext context, Camera camera, ref CullingResults cullingResults)
         {
             // Draw legacy Canvas UI meshes.
-            var sortingSettings = new SortingSettings(camera);
+            var sortingSettings = new SortingSettings(camera)
+            {
+                criteria = SortingCriteria.CommonTransparent
+            };
             var drawSettings = new DrawingSettings(PSXShaderPassNames.s_SRPDefaultUnlit, sortingSettings);
             var filterSettings = FilteringSettings.defaultValue;
             context.DrawRenderers(cullingResults, ref drawSettings, ref filterSettings);


### PR DESCRIPTION
Test scene: canvas with "I should be ahead" button has a smaller Plane Distance value and higher Sorting Order value, yet is sorted behind the other canvas.

Before fix:
![image](https://user-images.githubusercontent.com/3935328/137826318-05bcd456-8e7b-4374-8a49-36d9782fa0f2.png)

After fix:
![image](https://user-images.githubusercontent.com/3935328/137826337-6c9768f4-89b3-4540-8d84-67d556cfe540.png)
