### PR TITLE
Enable texture filtering for terrain details

### DIFF
--- a/Runtime/Material/PSXTerrain/PSXWavingGrass.shader
+++ b/Runtime/Material/PSXTerrain/PSXWavingGrass.shader
@@ -47,6 +47,7 @@ Shader "Hidden/TerrainEngine/Details/PSX/WavingDoublePass"
             // #pragma shader_feature _ _ALPHAPREMULTIPLY_ON _ALPHAMODULATE_ON
             // #pragma shader_feature _REFLECTION_ON
             #define _FOG_ON
+            #define _TEXTURE_FILTER_MODE_POINT
 
 
             // -------------------------------------

--- a/Runtime/Material/PSXTerrain/PSXWavingGrassBillboard.shader
+++ b/Runtime/Material/PSXTerrain/PSXWavingGrassBillboard.shader
@@ -48,6 +48,7 @@ Shader "Hidden/TerrainEngine/Details/PSX/BillboardWavingDoublePass"
             // #pragma shader_feature _REFLECTION_ON
             #define _FOG_ON
             #define _BRDF_MODE_LAMBERT
+            #define _TEXTURE_FILTER_MODE_POINT
 
             // -------------------------------------
             // Unity defined keywords

--- a/Runtime/Material/PSXTerrain/PSXWavingGrassInput.hlsl
+++ b/Runtime/Material/PSXTerrain/PSXWavingGrassInput.hlsl
@@ -18,6 +18,7 @@ CBUFFER_END
 
 CBUFFER_START(UnityPerMaterial)
 float4 _MainTex_ST;
+float4 _MainTex_TexelSize;
 half4 _BaseColor;
 half4 _SpecColor;
 half4 _EmissionColor;

--- a/Runtime/Material/PSXTerrain/PSXWavingGrassPasses.hlsl
+++ b/Runtime/Material/PSXTerrain/PSXWavingGrassPasses.hlsl
@@ -176,9 +176,13 @@ half4 LitPassFragmentGrass(GrassVaryings i) : SV_Target
 
     float2 uv = i.uvw.xy * interpolatorNormalization;
 
-    float2 colorUV = TRANSFORM_TEX(uv, _MainTex);
+    float2 uvColor = TRANSFORM_TEX(uv, _MainTex);
 
-    float4 color = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, colorUV);
+    float4 texelSizeLod;
+    float lod;
+    ComputeLODAndTexelSizeMaybeCallDDX(texelSizeLod, lod, uvColor, _MainTex_TexelSize);
+    
+    float4 color = SampleTextureWithFilterMode(TEXTURE2D_ARGS(_MainTex, sampler_MainTex), uvColor, texelSizeLod, lod);
 
 #if defined(_ALPHATEST_ON)
     // Perform alpha cutoff transparency (i.e: discard pixels in the holes of a chain link fence texture, or in the negative space of a leaf texture).


### PR DESCRIPTION
![hpsxrp_terrain_grass_texture_filtering](https://user-images.githubusercontent.com/372642/175800741-e2296242-ee69-45c8-8332-2f54423aa9fd.gif)

Enables texture filtering for terrain grass details. Refactors `PSXWavingGrassPasses.hlsl` to use the texture filtering method from `MaterialFunctions.hlsl`. Based off my inital attempt posted on the [HPSX Discord](https://discord.com/channels/427943144915599371/697158407601258556/984204564951597067).

Currently this enables the point filtering to verify my changes. I don't believe there is a good way for users to set keywords for these materials, so the only way forward I can see is to duplicate the shaders with the keyword defined. Then users can plug whichever shader they want into the RP resources asset.
