### PR TITLE
Bugfix: add other graphic renderers to Compression.compute

### DIFF
--- a/Runtime/PostProcessing/Shaders/Compression.compute
+++ b/Runtime/PostProcessing/Shaders/Compression.compute
@@ -14,7 +14,7 @@
 #pragma kernel CSMain10 CSMain=CSMain10 _COMPRESSION_MODE_FAST _COLORSPACE_YCBCRJPEG
 #pragma kernel CSMain11 CSMain=CSMain11 _COMPRESSION_MODE_FAST _COLORSPACE_SRGB
 
-#pragma only_renderers d3d11
+#pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
 
 //The Input/Output Textures
 RWTexture2D<float4> _CompressionSource;


### PR DESCRIPTION
Potential mac shader fix as discussed on [Discord](https://discord.com/channels/427943144915599371/697158407601258556/960014070298329148)

Error was introduced in https://github.com/pastasfuture/com.hauntedpsx.render-pipelines.psx/commit/a9aab081a88ce9f9d55780ac23477c678f91af8d

Have updated `Compression.compute` shader inline with other pragma directives

```
Runtime/PostProcessing/Shaders/CopyColorRespectFlipY.shader
6:    // #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch

Runtime/PostProcessing/Shaders/CRT.shader
6:    // #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch

Runtime/PostProcessing/Shaders/AccumulationMotionBlur.shader
6:    // #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch

Runtime/PostProcessing/Shaders/Sky.shader
6:    // #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch

Runtime/PostProcessing/Shaders/Compression.compute
17:#pragma only_renderers d3d11
```