### PR TITLE
New Volume Feature: Terrain Grass: The Terrain Grass Volume allows th…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 ---------------------------------------------------------------------------------------------------------------------------
+New Volume Feature: **Terrain Grass**
+---------------------------------------------------------------------------------------------------------------------------
+The Terrain Grass Volume allows the Haunted PSX Render Pipeline to expose additional custom properties for the Terrain Grass shaders.
+In the future, this Terrain Grass Volume will likely expose more HPSXRP material features that were previously unmodifiable on the Terrain Grass shaders.
+Special thanks to joshuaskelly for the first pass at the implementation of terrain grass filtering.
+**Texture Filter Mode**: Controls how the Terrain Grass textures are filtered.
+TextureFilterMode.TextureImportSettings is the standard unity behavior. Textures will be filtered using the texture's import settings.
+TextureFilterMode.Point will force PSX era nearest neighbor point sampling, regardless of texture import settings.
+TextureFilterMode.PointMipmaps is the same as TextureFilterMode.Point but supports supports point sampled lods via the texture's mipmap chain.
+TextureFilterMode.N64 will force N64 era 3-point barycentric texture filtering.
+TextureFilterMode.N64MipMaps is the same as TextureFilterMode.N64 but supports N64 sampled lods via the texture's mipmap chain.
+
+---------------------------------------------------------------------------------------------------------------------------
 Bugfix: **Compression compute shader compile on all supported platforms**
 ---------------------------------------------------------------------------------------------------------------------------
 Compression.compute erroneously was flagged to only compile on dx11. Now flagged to compile on all platforms that support it.
@@ -56,7 +69,7 @@ Bugfix: **Failed to present D3D11 swapchain due to device reset/removed.**
 ---------------------------------------------------------------------------------------------------------------------------
 Fixed bug where editor crashed for some users when editor was setup with multiple viewports (i.e: scene view, game view, material preview).
 The bug turned out to be a bug within the SRP Batcher, triggered (but not directly caused) by some UnityPerMaterial layout changes in PSXLitInputs.hlsl.
-The SRP Batcher has been manually disabled in HPSXRP until the Unity engine bug is tracked down / resolved. 
+The SRP Batcher has been manually disabled in HPSXRP until the Unity engine bug is tracked down / resolved.
 
 ---------------------------------------------------------------------------------------------------------------------------
 Bugfix: **CRT Shader Scanline Size and Vignette**
@@ -128,12 +141,12 @@ To use Shadow Mask shadows:
 
 For more information on the Shadow Mask feature in unity, visit: https://docs.unity3d.com/Manual/LightMode-Mixed-Shadowmask.html
 
-Note: If ANY light source in your scene requests Shadow Mask, HPSXRP will use Shadow Mask mode for ALL Mixed light sources. You cannot have some lights set to Mixed and some lights set to baked. Of NO light sources request Shadow Mask, HPSXRP will automatically configure itself to expect Lighting Mode->Baked Indirect data. 
+Note: If ANY light source in your scene requests Shadow Mask, HPSXRP will use Shadow Mask mode for ALL Mixed light sources. You cannot have some lights set to Mixed and some lights set to baked. Of NO light sources request Shadow Mask, HPSXRP will automatically configure itself to expect Lighting Mode->Baked Indirect data.
 
 ---------------------------------------------------------------------------------------------------------------------------
 Bugfix Fog Volume: **Fog Color LUT Modes**
 ---------------------------------------------------------------------------------------------------------------------------
-Fixed WebGL compatibility issue with Fog Color LUT Modes. WebGL doesn't support SAMPLE_TEXTURE2D_LOD or SAMPLE_CUBE_LOD - replaced with SAMPLE_TEXTURE2D and SAMPLE_CUBE. The LOD call was unnecessary. 
+Fixed WebGL compatibility issue with Fog Color LUT Modes. WebGL doesn't support SAMPLE_TEXTURE2D_LOD or SAMPLE_CUBE_LOD - replaced with SAMPLE_TEXTURE2D and SAMPLE_CUBE. The LOD call was unnecessary.
 
 ---------------------------------------------------------------------------------------------------------------------------
 New Volume Feature: **Accumulation Motion Blur Volume**
@@ -187,7 +200,7 @@ New Fog Volume Feature: **Color LUT Texture**
 ---------------------------------------------------------------------------------------------------------------------------
 New Material Feature: **Shading Evaluation Mode: Per-Object**
 ---------------------------------------------------------------------------------------------------------------------------
-**Shading Evaluation Mode: Per-Object**: Evaluates lighting and fog at the object origin, rather than per-vertex or per-pixel. This is useful for replicating lighting and fog artifacts that would occur when per-vertex or per-pixel lighting could not be afforded. Note, this has approximately the same performance cost as per-vertex, it is not optimization. This is due to the fact that in our render pipeline (in the context of unity SRP), it is more convinient and likely more efficient to still perform lighting in the vertex shader, rather than running say a CPU-side job to calculate lighting per-object. 
+**Shading Evaluation Mode: Per-Object**: Evaluates lighting and fog at the object origin, rather than per-vertex or per-pixel. This is useful for replicating lighting and fog artifacts that would occur when per-vertex or per-pixel lighting could not be afforded. Note, this has approximately the same performance cost as per-vertex, it is not optimization. This is due to the fact that in our render pipeline (in the context of unity SRP), it is more convinient and likely more efficient to still perform lighting in the vertex shader, rather than running say a CPU-side job to calculate lighting per-object.
 
 ---------------------------------------------------------------------------------------------------------------------------
 Workflow Improvement: **Precision Volume->Geometry Pushback Disabled by Default**

--- a/Editor/Volume/TerrainGrassVolumeEditor.cs
+++ b/Editor/Volume/TerrainGrassVolumeEditor.cs
@@ -1,0 +1,26 @@
+using UnityEditor;
+using UnityEditor.Rendering;
+using UnityEngine;
+using UnityEngine.Rendering;
+using HauntedPSX.RenderPipelines.PSX.Runtime;
+
+namespace HauntedPSX.RenderPipelines.PSX.Editor
+{
+    [CanEditMultipleObjects]
+    [VolumeComponentEditor(typeof(TerrainGrassVolume))]
+    public class TerrainGrassVolumeEditor : VolumeComponentEditor
+    {
+        SerializedDataParameter m_TextureFilterMode;
+
+        public override void OnEnable()
+        {
+            var o = new PropertyFetcher<TerrainGrassVolume>(serializedObject);
+            m_TextureFilterMode = Unpack(o.Find(x => x.textureFilterMode));
+        }
+
+        public override void OnInspectorGUI()
+        {
+            PropertyField(m_TextureFilterMode, EditorGUIUtility.TrTextContent("Texture Filter Mode", "Controls how the Terrain Grass textures are filtered.\nTextureFilterMode.TextureImportSettings is the standard unity behavior. Textures will be filtered using the texture's import settings.\nTextureFilterMode.Point will force PSX era nearest neighbor point sampling, regardless of texture import settings.\nTextureFilterMode.PointMipmaps is the same as TextureFilterMode.Point but supports supports point sampled lods via the texture's mipmap chain.\nTextureFilterMode.N64 will force N64 era 3-point barycentric texture filtering.\nTextureFilterMode.N64MipMaps is the same as TextureFilterMode.N64 but supports N64 sampled lods via the texture's mipmap chain."));
+        }
+    }
+}

--- a/Editor/Volume/TerrainGrassVolumeEditor.cs.meta
+++ b/Editor/Volume/TerrainGrassVolumeEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2825c97b86d29af4792336fa1761d536
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Material/PSXTerrain/PSXWavingGrass.shader
+++ b/Runtime/Material/PSXTerrain/PSXWavingGrass.shader
@@ -48,6 +48,21 @@ Shader "Hidden/TerrainEngine/Details/PSX/WavingDoublePass"
             // #pragma shader_feature _REFLECTION_ON
             #define _FOG_ON
 
+            #pragma shader_feature _TERRAIN_GRASS_TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS _TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT _TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT_MIPMAPS _TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64 _TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64_MIPMAPS
+            
+            #if defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS)
+                #define _TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS
+            #elif defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT)
+                #define _TEXTURE_FILTER_MODE_POINT
+            #elif defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT_MIPMAPS)
+                #define _TEXTURE_FILTER_MODE_POINT_MIPMAPS
+            #elif defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64)
+                #define _TEXTURE_FILTER_MODE_N64
+            #elif defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64_MIPMAPS)
+                #define _TEXTURE_FILTER_MODE_N64_MIPMAPS
+            #else
+                #define _TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS
+            #endif
 
             // -------------------------------------
             // Unity defined keywords
@@ -110,6 +125,22 @@ Shader "Hidden/TerrainEngine/Details/PSX/WavingDoublePass"
             // #pragma shader_feature _ _ALPHAPREMULTIPLY_ON _ALPHAMODULATE_ON
             // #pragma shader_feature _REFLECTION_ON
             // #define _FOG_ON
+
+            #pragma shader_feature _TERRAIN_GRASS_TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS _TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT _TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT_MIPMAPS _TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64 _TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64_MIPMAPS
+
+            #if defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS)
+                #define _TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS
+            #elif defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT)
+                #define _TEXTURE_FILTER_MODE_POINT
+            #elif defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT_MIPMAPS)
+                #define _TEXTURE_FILTER_MODE_POINT_MIPMAPS
+            #elif defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64)
+                #define _TEXTURE_FILTER_MODE_N64
+            #elif defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64_MIPMAPS)
+                #define _TEXTURE_FILTER_MODE_N64_MIPMAPS
+            #else
+                #define _TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS
+            #endif
 
             // -------------------------------------
             // Material Keywords

--- a/Runtime/Material/PSXTerrain/PSXWavingGrassBillboard.shader
+++ b/Runtime/Material/PSXTerrain/PSXWavingGrassBillboard.shader
@@ -49,6 +49,22 @@ Shader "Hidden/TerrainEngine/Details/PSX/BillboardWavingDoublePass"
             #define _FOG_ON
             #define _BRDF_MODE_LAMBERT
 
+            #pragma shader_feature _TERRAIN_GRASS_TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS _TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT _TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT_MIPMAPS _TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64 _TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64_MIPMAPS
+
+            #if defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS)
+                #define _TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS
+            #elif defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT)
+                #define _TEXTURE_FILTER_MODE_POINT
+            #elif defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT_MIPMAPS)
+                #define _TEXTURE_FILTER_MODE_POINT_MIPMAPS
+            #elif defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64)
+                #define _TEXTURE_FILTER_MODE_N64
+            #elif defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64_MIPMAPS)
+                #define _TEXTURE_FILTER_MODE_N64_MIPMAPS
+            #else
+                #define _TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS
+            #endif
+
             // -------------------------------------
             // Unity defined keywords
             #pragma multi_compile _ DIRLIGHTMAP_COMBINED
@@ -101,6 +117,22 @@ Shader "Hidden/TerrainEngine/Details/PSX/BillboardWavingDoublePass"
             // #pragma shader_feature _REFLECTION_ON
             // #define _FOG_ON
             #define _BRDF_MODE_LAMBERT
+
+            #pragma shader_feature _TERRAIN_GRASS_TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS _TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT _TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT_MIPMAPS _TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64 _TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64_MIPMAPS
+
+            #if defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS)
+                #define _TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS
+            #elif defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT)
+                #define _TEXTURE_FILTER_MODE_POINT
+            #elif defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT_MIPMAPS)
+                #define _TEXTURE_FILTER_MODE_POINT_MIPMAPS
+            #elif defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64)
+                #define _TEXTURE_FILTER_MODE_N64
+            #elif defined(_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64_MIPMAPS)
+                #define _TEXTURE_FILTER_MODE_N64_MIPMAPS
+            #else
+                #define _TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS
+            #endif
 
             #pragma vertex DepthOnlyVertex
             #pragma fragment DepthOnlyFragment

--- a/Runtime/Material/PSXTerrain/PSXWavingGrassInput.hlsl
+++ b/Runtime/Material/PSXTerrain/PSXWavingGrassInput.hlsl
@@ -18,6 +18,7 @@ CBUFFER_END
 
 CBUFFER_START(UnityPerMaterial)
 float4 _MainTex_ST;
+float4 _MainTex_TexelSize;
 half4 _BaseColor;
 half4 _SpecColor;
 half4 _EmissionColor;

--- a/Runtime/Material/PSXTerrain/PSXWavingGrassPasses.hlsl
+++ b/Runtime/Material/PSXTerrain/PSXWavingGrassPasses.hlsl
@@ -176,9 +176,13 @@ half4 LitPassFragmentGrass(GrassVaryings i) : SV_Target
 
     float2 uv = i.uvw.xy * interpolatorNormalization;
 
-    float2 colorUV = TRANSFORM_TEX(uv, _MainTex);
+    float2 uvColor = TRANSFORM_TEX(uv, _MainTex);
 
-    float4 color = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, colorUV);
+    float4 texelSizeLod;
+    float lod;
+    ComputeLODAndTexelSizeMaybeCallDDX(texelSizeLod, lod, uvColor, _MainTex_TexelSize);
+    
+    float4 color = SampleTextureWithFilterMode(TEXTURE2D_ARGS(_MainTex, sampler_MainTex), uvColor, texelSizeLod, lod);
 
 #if defined(_ALPHATEST_ON)
     // Perform alpha cutoff transparency (i.e: discard pixels in the holes of a chain link fence texture, or in the negative space of a leaf texture).

--- a/Runtime/RenderPipeline/PSXRenderPipeline.cs
+++ b/Runtime/RenderPipeline/PSXRenderPipeline.cs
@@ -296,6 +296,7 @@ namespace HauntedPSX.RenderPipelines.PSX.Runtime
                     PushTonemapperParameters(camera, cmd);
                     PushDynamicLightingParameters(camera, cmd, ref cullingResults);
                     PushSkyParameters(camera, cmd, skyMaterial, m_Asset, rasterizationWidth, rasterizationHeight);
+                    PushTerrainGrassParameters(camera, cmd, m_Asset, rasterizationWidth, rasterizationHeight);
                     PSXRenderPipeline.DrawFullScreenQuad(cmd, skyMaterial);
                     context.ExecuteCommandBuffer(cmd);
                     cmd.Release();
@@ -1256,6 +1257,75 @@ namespace HauntedPSX.RenderPipelines.PSX.Runtime
                 }
 
                 cmd.SetGlobalFloat(PSXShaderIDs._SkyFramebufferDitherWeight, volumeSettings.framebufferDitherWeight.value);
+            }
+        }
+
+        static void PushTerrainGrassParameters(Camera camera, CommandBuffer cmd, PSXRenderPipelineAsset asset, int rasterizationWidth, int rasterizationHeight)
+        {
+            using (new ProfilingScope(cmd, PSXProfilingSamplers.s_PushTerrainGrassParameters))
+            {
+                var volumeSettings = VolumeManager.instance.stack.GetComponent<TerrainGrassVolume>();
+                if (!volumeSettings) volumeSettings = TerrainGrassVolume.@default;
+
+                TerrainGrassVolume.TextureFilterMode textureFilterMode = volumeSettings.textureFilterMode.value;
+                switch (textureFilterMode)
+                {
+                    case TerrainGrassVolume.TextureFilterMode.TextureImportSettings:
+                        {
+                            cmd.EnableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS);
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT);
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT_MIPMAPS);
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64);
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64_MIPMAPS);
+                            break;
+                        }
+
+                    case TerrainGrassVolume.TextureFilterMode.Point:
+                        {
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS);
+                            cmd.EnableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT);
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT_MIPMAPS);
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64);
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64_MIPMAPS);
+                            break;
+                        }
+
+                    case TerrainGrassVolume.TextureFilterMode.PointMipmaps:
+                        {
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS);
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT);
+                            cmd.EnableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT_MIPMAPS);
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64);
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64_MIPMAPS);
+                            break;
+                        }
+
+                    case TerrainGrassVolume.TextureFilterMode.N64:
+                        {
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS);
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT);
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT_MIPMAPS);
+                            cmd.EnableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64);
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64_MIPMAPS);
+                            break;
+                        }
+
+                    case TerrainGrassVolume.TextureFilterMode.N64Mipmaps:
+                        {
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS);
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT);
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT_MIPMAPS);
+                            cmd.DisableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64);
+                            cmd.EnableShaderKeyword(PSXShaderKeywords.s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64_MIPMAPS);
+                            break;
+                        }
+
+                    default:
+                        {
+                            Debug.Assert(false, "Error: Encountered unsupported TextureFilterMode.");
+                            break;
+                        }
+                }
             }
         }
 

--- a/Runtime/RenderPipeline/PSXStringContants.cs
+++ b/Runtime/RenderPipeline/PSXStringContants.cs
@@ -32,6 +32,7 @@ namespace HauntedPSX.RenderPipelines.PSX.Runtime
         public static readonly string s_DrawAccumulationMotionBlurPreUIOverlayStr = "Accumulation Motion Blur Pre UI Overlay";
         public static readonly string s_DrawAccumulationMotionBlurPostUIOverlayStr = "Accumulation Motion Blur Post UI Overlay";
         public static readonly string s_DrawAccumulationMotionBlurFinalBlitStr = "Accumulation Motion Blur Final Blit";
+        public static readonly string s_PushTerrainGrassParametersStr = "Push Terrain Grass Parameters";
 
         public static ProfilingSampler s_PushCameraParameters = new ProfilingSampler(s_PushCameraParametersStr);
         public static ProfilingSampler s_PushGlobalRasterizationParameters = new ProfilingSampler(s_PushGlobalRasterizationParametersStr);
@@ -50,6 +51,7 @@ namespace HauntedPSX.RenderPipelines.PSX.Runtime
         public static ProfilingSampler s_DrawAccumulationMotionBlurPreUIOverlay = new ProfilingSampler(s_DrawAccumulationMotionBlurPreUIOverlayStr);
         public static ProfilingSampler s_DrawAccumulationMotionBlurPostUIOverlay = new ProfilingSampler(s_DrawAccumulationMotionBlurPostUIOverlayStr);
         public static ProfilingSampler s_DrawAccumulationMotionBlurFinalBlit = new ProfilingSampler(s_DrawAccumulationMotionBlurFinalBlitStr);
+        public static ProfilingSampler s_PushTerrainGrassParameters = new ProfilingSampler(s_PushTerrainGrassParametersStr);
     }
 
     internal static class PSXShaderPassNames
@@ -82,6 +84,11 @@ namespace HauntedPSX.RenderPipelines.PSX.Runtime
         public static readonly string s_TEXTURE_FILTER_MODE_POINT_MIPMAPS = "_TEXTURE_FILTER_MODE_POINT_MIPMAPS";
         public static readonly string s_TEXTURE_FILTER_MODE_N64 = "_TEXTURE_FILTER_MODE_N64";
         public static readonly string s_TEXTURE_FILTER_MODE_N64_MIPMAPS = "_TEXTURE_FILTER_MODE_N64_MIPMAPS";
+        public static readonly string s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS = "_TERRAIN_GRASS_TEXTURE_FILTER_MODE_TEXTURE_IMPORT_SETTINGS";
+        public static readonly string s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT = "_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT";
+        public static readonly string s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT_MIPMAPS = "_TERRAIN_GRASS_TEXTURE_FILTER_MODE_POINT_MIPMAPS";
+        public static readonly string s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64 = "_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64";
+        public static readonly string s_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64_MIPMAPS = "_TERRAIN_GRASS_TEXTURE_FILTER_MODE_N64_MIPMAPS";
         public static readonly string s_FOG_COLOR_LUT_MODE_DISABLED = "_FOG_COLOR_LUT_MODE_DISABLED";
         public static readonly string s_FOG_COLOR_LUT_MODE_TEXTURE2D_DISTANCE_AND_HEIGHT = "_FOG_COLOR_LUT_MODE_TEXTURE2D_DISTANCE_AND_HEIGHT";
         public static readonly string s_FOG_COLOR_LUT_MODE_TEXTURECUBE = "_FOG_COLOR_LUT_MODE_TEXTURECUBE";

--- a/Runtime/Volume/TerrainGrassVolume.cs
+++ b/Runtime/Volume/TerrainGrassVolume.cs
@@ -1,0 +1,45 @@
+using System;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace HauntedPSX.RenderPipelines.PSX.Runtime
+{
+    [Serializable, VolumeComponentMenu("HauntedPS1/TerrainGrassVolume")]
+    public class TerrainGrassVolume : VolumeComponent
+    {
+        // TODO: This type was copied from the editor-only PSXMaterialUtils static class.
+        // Should look into creating a runtime static class for these types to be shared across editor and runtime (i.e: PSXMaterialTypes? PSXTypes?)
+        [Serializable]
+        public enum TextureFilterMode
+        {
+            TextureImportSettings = 0,
+            Point,
+            PointMipmaps,
+            N64,
+            N64Mipmaps
+        };
+
+        [Serializable]
+        public sealed class TextureFilterModeParameter : VolumeParameter<TextureFilterMode>
+        {
+            public TextureFilterModeParameter(TextureFilterMode value, bool overrideState = false)
+                : base(value, overrideState) { }
+        }
+
+        public TextureFilterModeParameter textureFilterMode = new TextureFilterModeParameter(TextureFilterMode.TextureImportSettings);
+
+        static TerrainGrassVolume s_Default = null;
+        public static TerrainGrassVolume @default
+        {
+            get
+            {
+                if (s_Default == null)
+                {
+                    s_Default = ScriptableObject.CreateInstance<TerrainGrassVolume>();
+                    s_Default.hideFlags = HideFlags.HideAndDontSave;
+                }
+                return s_Default;
+            }
+        }
+    }
+}

--- a/Runtime/Volume/TerrainGrassVolume.cs.meta
+++ b/Runtime/Volume/TerrainGrassVolume.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 73811fdb48dddb143add2662b3aba7bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
…e Haunted PSX Render Pipeline to expose additional custom properties for the Terrain Grass shaders.

In the future, this Terrain Grass Volume will likely expose more HPSXRP material features that were previously unmodifiable on the Terrain Grass shaders. Special thanks to joshuaskelly for the first pass at the implementation of terrain grass filtering.

First pass of implementation here: https://github.com/pastasfuture/com.hauntedpsx.render-pipelines.psx/pull/30